### PR TITLE
fix: color typo on lime-5

### DIFF
--- a/packages/tailwindcss-plugin/krds-plugin.js
+++ b/packages/tailwindcss-plugin/krds-plugin.js
@@ -223,7 +223,7 @@ module.exports = plugin(
             90: '#0A290A',
           },
           lime: {
-            5: '#F7FEA',
+            5: '#F7FFEA',
             10: '#EEFEDA',
             20: '#DCFFAB',
             30: '#CEFE83',


### PR DESCRIPTION
컬러에 오타가 있어서 수정합니다.

## Summary by Sourcery

Bug Fixes:
- Correct the hexadecimal color code for the lime-5 color.